### PR TITLE
Brad breaks console help

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,6 +10,8 @@ class Plugin extends \craft\base\Plugin
 {
     public function init()
     {
+        parent::init();
+
         Event::on(Dashboard::class, Dashboard::EVENT_REGISTER_WIDGET_TYPES, function(RegisterComponentTypesEvent $e) {
             $e->types[] = Widget::class;
         });


### PR DESCRIPTION
Hi Matt,

as the `parent::init()` wasn't called, `$module->controllerNamespace` wasn't declared.

## How to reproduce the error

1. Install the plugin
2. Enable the plugin
3. Fire up the console (help) `php craft `


```
Exception 'yii\base\InvalidArgumentException' with message 'Invalid path alias: @'

in /Users/os/Projects/Craft/demo/vendor/yiisoft/yii2/BaseYii.php:154

Stack trace:
#0 /Users/os/Projects/Craft/demo/vendor/yiisoft/yii2/base/Module.php(257): yii\BaseYii::getAlias('@')
#1 /Users/os/Projects/Craft/demo/vendor/yiisoft/yii2/console/controllers/HelpController.php(250): yii\base\Module->getControllerPath()
#2 /Users/os/Projects/Craft/demo/vendor/yiisoft/yii2/console/controllers/HelpController.php(245): yii\console\controllers\HelpController->getModuleCommands(Object(mattstauffer\happybrad\Plugin))
#
```